### PR TITLE
fix(demo): make demo shell scripts compatible with Mac and Linux

### DIFF
--- a/appactive-demo/quit.sh
+++ b/appactive-demo/quit.sh
@@ -14,4 +14,8 @@
 # limitations under the License.
 #
 
-docker-compose down
+if [[ -z $1 ]]; then
+  docker-compose down
+else
+  docker-compose -f "$1" down
+fi

--- a/appactive-demo/run-nacos-quick.sh
+++ b/appactive-demo/run-nacos-quick.sh
@@ -16,7 +16,7 @@
 
 export appactiveNamespaceId="appactiveDemoNamespaceId"
 docker-compose -f docker-compose-nacos-quick.yml up -d nacos mysql
-sleep 40s
+sleep 40
 
 curl -X POST 'http://127.0.0.1:8848/nacos/v1/console/namespaces' -d 'customNamespaceId=appactiveDemoNamespaceId&namespaceName=appactiveDemoNamespaceName&namespaceDesc=appactiveDemoNamespaceDesc'
 
@@ -25,14 +25,14 @@ sh baseline.sh 2 NACOS appactiveDemoNamespaceId
 
 cd ../appactive-demo
 docker-compose -f docker-compose-nacos-quick.yml up -d storage storage-unit
-sleep 15s
+sleep 15
 docker-compose -f docker-compose-nacos-quick.yml up -d product product-unit
-sleep 15s
+sleep 15
 docker-compose -f docker-compose-nacos-quick.yml up -d frontend frontend-unit
-sleep 3s
+sleep 3
 docker-compose -f docker-compose-nacos-quick.yml up -d gateway
 
-sleep 3s
+sleep 3
 cd ../appactive-portal
 sh baseline.sh 3
 

--- a/appactive-demo/run-nacos.sh
+++ b/appactive-demo/run-nacos.sh
@@ -29,11 +29,11 @@ then
   export appactiveNamespaceId="${temp}"
   docker-compose -f docker-compose-nacos.yml build
   docker-compose -f docker-compose-nacos.yml up -d storage storage-unit
-  sleep 15s
+  sleep 15
   docker-compose -f docker-compose-nacos.yml up -d product product-unit
-  sleep 15s
+  sleep 15
   docker-compose -f docker-compose-nacos.yml up -d frontend frontend-unit
-  sleep 3s
+  sleep 3
   docker-compose -f docker-compose-nacos.yml up -d gateway
 fi
 

--- a/appactive-demo/run-quick.sh
+++ b/appactive-demo/run-quick.sh
@@ -20,16 +20,16 @@ sh baseline.sh 2
 
 cd ../appactive-demo
 docker-compose -f docker-compose-quick.yml up -d nacos mysql
-sleep 20s
+sleep 20
 docker-compose -f docker-compose-quick.yml up -d storage storage-unit
-sleep 15s
+sleep 15
 docker-compose -f docker-compose-quick.yml up -d product product-unit
-sleep 15s
+sleep 15
 docker-compose -f docker-compose-quick.yml up -d frontend frontend-unit
-sleep 3s
+sleep 3
 docker-compose -f docker-compose-quick.yml up -d gateway
 
-sleep 3s
+sleep 3
 cd ../appactive-portal
 sh baseline.sh 3
 

--- a/appactive-demo/run.sh
+++ b/appactive-demo/run.sh
@@ -16,13 +16,13 @@
 
 docker-compose build
 docker-compose up -d nacos mysql
-sleep 20s
+sleep 20
 docker-compose up -d storage storage-unit
-sleep 15s
+sleep 15
 docker-compose up -d product product-unit
-sleep 15s
+sleep 15
 docker-compose up -d frontend frontend-unit
-sleep 3s
+sleep 3
 docker-compose up -d gateway
 
 # docker-compose up --no-recreate

--- a/appactive-portal/cut.sh
+++ b/appactive-portal/cut.sh
@@ -69,7 +69,7 @@ echo "$(date "+%Y-%m-%d %H:%M:%S") gateway 新规则推送结果: " && curl --he
 127.0.0.1:8090/set
 
 echo "等待数据追平......"
-sleep "${waitTime}s"
+sleep "${waitTime}"
 echo "数据已经追平，下发新规则......"
 
 if [ $channel = "FILE" ]

--- a/docs/cn/details/demo.md
+++ b/docs/cn/details/demo.md
@@ -49,7 +49,7 @@ nav_order: 7
 2. 绑定本地 host: `127.0.0.1 demo.appactive.io`，浏览器访问 `http://demo.appactive.io/buyProduct?r_id=2000` 查看效果
 3. 在`appactive-portal` 模块中运行 `sh cut.sh` 进行切流 。需要注意的是，本 demo 的禁写规则是写死的，用户若要更换切流范围则需自行计算禁写规则和下次路由规则，然后执行切流。
 
-> 如果你打算停止体验，可进行：`cd appactive-demo` -> `docker-compose down`
+> 如果你打算停止体验，可进行：`cd appactive-demo` -> `sh quit.sh`
 
 ## 源码构建
 

--- a/docs/cn/details/demo_nacos.md
+++ b/docs/cn/details/demo_nacos.md
@@ -52,7 +52,7 @@ nav_order: 3
 2. 绑定本地 host: `127.0.0.1 demo.appactive.io`，浏览器访问 `http://demo.appactive.io/buyProduct?r_id=2000` 查看效果
 3. 在`appactive-portal` 模块中运行 `sh cut.sh NACOS appactiveDemoNamespaceId` 进行切流 。需要注意的是，本 demo 的禁写规则是写死的，用户若要更换切流范围则需自行计算禁写规则和下次路由规则，然后执行切流。
 
-> 如果你打算停止体验，可进行：`cd appactive-demo` -> `sh quit.sh`
+> 如果你打算停止体验，可进行：`cd appactive-demo` -> `sh quit.sh ./docker-compose-nacos-quick.yml`
 
 若想直接体验，请见[官方demo站点](http://demo.appactive.io/)
 


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Appactive/blob/master/docs/en/contributing/contributing.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Make demo shell scripts compatible with Mac and Linux.

The **sleep** command on both Mac and Linux supports commands like "sleep [xx]" instead of "sleep [xx]s".

### Does this pull request fix one issue?
NONE
<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
change "sleep [xx]s" to "sleep [xx]" in shell scripts

### Describe how to verify it
run shell scripts and work fine.

### Special notes for reviews
NONE